### PR TITLE
Make module enablement optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This project provides Okapi deployment automation when deploying Okapi modules on Kubernetes.
 
-`okapi-hooks` is a helper container for Okapi module registration (deploy + install/uninstall + undeploy)
+`okapi-hooks` is a helper container for Okapi module registration (deploy + optional install/uninstall + undeploy)
 and a corresponding Helm chart that binds to Helm's `post-instal` and `post-upgrade`
 [lifecycle hooks](https://helm.sh/docs/topics/charts_hooks/).
+
+If a list of Okapi tenants is provided, the module will be enabled (installed)
+for each tenant in the list.
 
 While the container and the chart can be used independently, the intended use is as a subchart dependency
 in a parent Okapi module Helm chart, like so:
@@ -31,15 +34,13 @@ moduleDescriptor: |
     "id" : "mod-x-0.1.0",
     "name" : "X Okapi module"
   }
-tenants:
-- mytenant
-
 ```
+
 It's recommended that the module version in the ModuleDescriptor follows the parent chart version.
 
 see [values.yaml](./chart/values.yaml) for a complete list of configuration options.
 
-The parent chart is then build with:
+The parent chart is then built with:
 
 ```bash
 cd /path/to/parent/chart

--- a/chart/templates/_validate.tpl
+++ b/chart/templates/_validate.tpl
@@ -12,7 +12,4 @@
 {{- if not .Values.moduleDescriptor -}}
 {{- fail "A valid .Values.moduleDescriptor is required!" -}}
 {{- end -}}
-{{- if empty .Values.tenants -}}
-{{- fail "A valid .Values.tenants is required!" -}}
-{{- end -}}
 {{- end -}}

--- a/chart/templates/okapi-hook-job.yaml
+++ b/chart/templates/okapi-hook-job.yaml
@@ -33,7 +33,7 @@ spec:
           - name: MODULE_URL
             value: "{{ .Values.moduleUrl }}"
           - name: OKAPI_TENANTS
-            value: "{{ join "," .Values.tenants }}"
+            value: "{{ join "," .Values.tenants | default([]) }}"
           - name: OKAPI_ADMIN_TENANT
             value: "{{ join "," .Values.supertenant }}"
           {{- range $k, $v := .Values.env }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,8 @@ moduleUrl: ""
 #ModuleDescriptor literal (JSON), NO DEFAULT
 moduleDescriptor: ""
 #Okapi tenant(s) to deploy the module to, NO DEFAULTS
+#If list is empty or undefined, module will be registered and deployed but
+#not enabled for any tenant
 tenants: []
 
 #REQUIRED values with defaults in the subchart, may be overridden by parent chart:


### PR DESCRIPTION
If `OKAPI_TENANTS` is empty or undefined, just skip the module enablement step. DEVOPS-6444.